### PR TITLE
:wrench: Add LDFLAGS after object files to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ endif
 OBJS = render.o render_txt.o pla.o utils.o main.o load.o utf8.o 
 
 pla: $(OBJS)
-	$(CC) -o pla $(LDFLAGS) $(OBJS)
+	$(CC) -o pla $(OBJS) $(LDFLAGS)
 
 clean: 
 	rm -f pla $(OBJS)


### PR DESCRIPTION
I was getting an issue where ld could not find a reference to the cairo
functions. It was caused by the -lcairo flag being passed BEFORE the
main.o, pla.o, etc... to g++.